### PR TITLE
Replace challenge details with div for custom accordion header

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,8 +154,7 @@
           </svg>
 
           <!-- Challenge Mode (v1 forward horizon) -->
-          <details class="challenge" id="chalCard">
-            <summary style="cursor:pointer;font-weight:700;color:var(--ink)">Challenge (optional)</summary>
+          <div class="challenge" id="chalCard">
             <div class="bar">
               <label class="muted small">Horizon</label>
               <select id="chalHorizon">
@@ -174,7 +173,7 @@
               <div class="legend-item"><span class="label">Spent / Left</span><span class="value" id="chalSpentLeft">—</span></div>
               <div class="legend-item"><span class="label">Rule</span><span class="value" id="chalExplain">Strict allowance, no decay</span></div>
             </div>
-          </details>
+          </div>
 
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaced the `chalCard` challenge section's `<details>` and default `<summary>` with a plain `<div>` so the custom accordion header can be rendered by JavaScript without a default summary.
- Confirmed `setupChallengeAccordion` continues to target `chalCard` and creates the "Challenge" header dynamically.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4571454b8832f8c523bf21726b47b