### PR TITLE
Apply daily recovery regardless of infractions

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,18 +268,20 @@
       const start=new Date(end);start.setDate(end.getDate()-(windowDays-1));
       const byDate=new Map(data.map(r=>[r.date,r.n]));
       let debt=0;const rows=[];
+      const dailyRec=windowDays/100;
       for(let i=0;i<windowDays;i++){
         const d=new Date(start);d.setDate(start.getDate()+i);
         const ds=d.toISOString().slice(0,10);
+        debt=Math.max(0,debt-dailyRec);
         const pts=byDate.get(ds)||0;
         if(pts>0){debt+=pts;rows.push({date:ds,n:pts});}
-        else if(debt>0){debt-=1;}
       }
       const allowed=Math.floor(0.2*windowDays);
-      const healthyPct=Math.round(((windowDays-Math.min(windowDays,debt))/windowDays)*100);
+      const healthyPct=Math.round(100-(Math.min(windowDays,debt)/windowDays)*100);
       let recovery=null;
       if(debt>allowed){
-        const rec=new Date(end);rec.setDate(end.getDate()+(debt-allowed));
+        const daysToAllowed=Math.ceil((debt-allowed)/dailyRec);
+        const rec=new Date(end);rec.setDate(end.getDate()+daysToAllowed);
         recovery=rec.toISOString().slice(0,10);
       }
       // streaks (current healthy run and best within window)


### PR DESCRIPTION
## Summary
- Remove no-infraction requirement from recovery logic so a day always deducts 1% of window size from debt
- Recalculate healthy percentage and recovery date using fractional debt

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b459cfa244832f8e32dedec60243a4