### PR TITLE
Apply daily recovery regardless of infractions

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,11 +272,11 @@
         const d=new Date(start);d.setDate(start.getDate()+i);
         const ds=d.toISOString().slice(0,10);
         const pts=byDate.get(ds)||0;
+        debt=Math.max(0,debt-1);
         if(pts>0){debt+=pts;rows.push({date:ds,n:pts});}
-        else if(debt>0){debt-=1;}
       }
       const allowed=Math.floor(0.2*windowDays);
-      const healthyPct=Math.round(((windowDays-Math.min(windowDays,debt))/windowDays)*100);
+      const healthyPct=Math.round(100-(Math.min(windowDays,debt)/windowDays)*100);
       let recovery=null;
       if(debt>allowed){
         const rec=new Date(end);rec.setDate(end.getDate()+(debt-allowed));


### PR DESCRIPTION
## Summary
- Always deduct one point of debt at the start of each day before adding new infractions
- Compute healthy percentage and recovery date using integer daily decay

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b459cfa244832f8e32dedec60243a4