### PR TITLE
Fix local date calculation for todayStr

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,10 @@
 
     const $ = s => document.querySelector(s);
     const $$ = s => Array.from(document.querySelectorAll(s));
-    const todayStr = (d=new Date()) => new Date(d.getFullYear(),d.getMonth(),d.getDate()).toISOString().slice(0,10);
+    const todayStr = (d=new Date()) =>
+      new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+        .toISOString()
+        .slice(0,10);
 
     function load(){
       let rows=[],prefs={window:30};


### PR DESCRIPTION
## Summary
- compute the `todayStr` helper using the device's timezone offset so entries use the correct local date

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ac42ce84832f860752afa177448c