### PR TITLE
fix: correct Pages workflow and remove staging job

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,4 @@
 name: Deploy site to GitHub Pages
-# Deploy to staging before production
 
 on:
   push:
@@ -16,29 +15,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy-staging:
+  deploy:
     environment:
-codex/create-prd-for-habit-tracker-feature
-      name: staging
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload site
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '.'
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@v4
-
-  deploy-production:
-    needs: deploy-staging
-    environment:
-main
       name: production
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Repo for Treat app.
 ## Preview
 
 This repository includes GitHub Pages workflows to publish the site.
-Enable GitHub Pages in the repository settings and the deployed site will be
-available at https://abzerra.github.io/Treat/ after pushing to `main`.
+Enable GitHub Pages in the repository settings and pushing to `main` publishes
+the production site at https://abzerra.github.io/Treat/. Staging previews are
+built from the `staging` branch.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- remove stray environment lines and redundant staging deploy from Pages workflow
- clarify production and staging deployment documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae6102470832fb9fd246881775d31