### PR TITLE
Use cat icon for favicon and Apple touch link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="theme-color" content="#A7E0DC" />
   <link id="favicon" rel="icon" type="image/png" />
+  <link id="apple-touch" rel="apple-touch-icon" />
   <link rel="manifest" href="manifest.webmanifest" />
 
   <style>
@@ -253,6 +254,7 @@
   <script type="module">
     import { CAT_ICON } from './icons/cat-icon.js';
     document.getElementById('favicon').href = CAT_ICON;
+    document.getElementById('apple-touch').href = CAT_ICON;
     document.getElementById('logo').src = CAT_ICON;
     document.querySelectorAll('.home-btn img').forEach(img => img.src = CAT_ICON);
 


### PR DESCRIPTION
## Summary
- restore cat-icon.js and remove binary icon
- set favicon and Apple touch icon to use the existing cat icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb08b42f74832fbf81f4a2589f7d9f