### PR TITLE
Fix missing browser tab icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="theme-color" content="#A7E0DC" />
-  <link id="favicon" rel="icon" type="image/png" href="data:image/png;base64,">
-  <link id="apple-touch" rel="apple-touch-icon" href="data:image/png;base64,">
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn5CIPC90ZXh0Pjwvc3ZnPg==">
+  <link rel="apple-touch-icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn5CIPC90ZXh0Pjwvc3ZnPg==">
   <link rel="manifest" href="manifest.webmanifest" />
 
   <style>
@@ -256,8 +256,6 @@
     import { CAT_ICON } from './icons/cat-icon.js';
     document.getElementById('logo').src = CAT_ICON;
     document.querySelectorAll('.home-btn img').forEach(img => img.src = CAT_ICON);
-    document.getElementById('favicon').href = CAT_ICON;
-    document.getElementById('apple-touch').href = CAT_ICON;
 
     // ===== Keys (v1) =====
     const KEY='mvp_points_v1';

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -5,5 +5,12 @@
   "scope": "./",
   "display": "standalone",
   "background_color": "#FAFAF5",
-  "theme_color": "#A7E0DC"
+  "theme_color": "#A7E0DC",
+  "icons": [
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn5CIPC90ZXh0Pjwvc3ZnPg==",
+      "sizes": "100x100",
+      "type": "image/svg+xml"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- embed favicon and apple-touch icon as inline SVG data URIs
- declare the same SVG in the PWA manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb10e2e878832fb740c8c4215c010a