### PR TITLE
Use muted styling for habit names

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,13 +103,8 @@
     /* Habits */
     .habit-list{display:flex;flex-direction:column;gap:6px}
     .habit-row{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border:1px solid var(--line);border-radius:8px;background:var(--panel)}
-codex/review-input-text-formatting-lmyoha
     .name{font-size:.95rem;color:var(--muted)}
-    .habit-row.completed .name{text-decoration:line-through}
-
-    .name{font-size:.95rem;font-weight:800;color:var(--ink)}
     .habit-row.completed .name{text-decoration:line-through;color:var(--muted)}
-main
 
     .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:calc(88px + env(safe-area-inset-bottom));background:#ffffff;border:1px solid #E7F1F0;box-shadow:var(--shadow);padding:10px 12px;border-radius:12px;font-weight:700;color:var(--ink);display:none;z-index:50}
 


### PR DESCRIPTION
## Summary
- Remove bold styling from habit names
- Gray out habit names using the muted color to match Streak label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed10dccd4832f8b5dcf74d925f0a9