### PR TITLE
Grey out cheat settings labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,15 +261,15 @@
       <div class="edit-card">
         <h3 style="margin:0 0 8px;font-size:1rem;font-weight:800;color:var(--ink)">Cheat Values</h3>
         <div class="form">
-          <label>Small <input type="number" id="valSmall" min="1" style="width:60px"></label>
-          <label>Medium <input type="number" id="valMedium" min="1" style="width:60px"></label>
-          <label>Large <input type="number" id="valLarge" min="1" style="width:60px"></label>
+          <label class="muted">Small <input type="number" id="valSmall" min="1" style="width:60px"></label>
+          <label class="muted">Medium <input type="number" id="valMedium" min="1" style="width:60px"></label>
+          <label class="muted">Large <input type="number" id="valLarge" min="1" style="width:60px"></label>
         </div>
       </div>
       <div class="edit-card">
         <h3 style="margin:0 0 8px;font-size:1rem;font-weight:800;color:var(--ink)">Recovery</h3>
         <div class="form">
-          <label>Daily amount <input type="number" id="valRecovery" min="0" style="width:80px"></label>
+          <label class="muted">Daily amount <input type="number" id="valRecovery" min="0" style="width:80px"></label>
         </div>
       </div>
       <div class="edit-card">


### PR DESCRIPTION
## Summary
- Make cheat value labels muted like the Streak label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed2863f14832fa0cb9b4a5042583d