### PR TITLE
Nest habit values under Recovery settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repo for Treat app.
 
 ## Customization
 
-The app includes a Settings page where you can change small, medium, and large cheat values as well as the daily recovery amount. Habit values can also be adjusted here. Each completed habit grants bonus recovery equal to its value for that day. The recovery cycle remains daily and the 80% health threshold is fixed. Recovery changes and habit value edits apply only to future days and do not alter past records.
+The app includes a Settings page where you can change small, medium, and large cheat values as well as the daily recovery amount. Habit values can also be adjusted under the Recovery section. Each completed habit grants bonus recovery equal to its value for that day. The recovery cycle remains daily and the 80% health threshold is fixed. Recovery changes and habit value edits apply only to future days and do not alter past records.
 
 ## Preview
 

--- a/index.html
+++ b/index.html
@@ -283,9 +283,7 @@
         <div class="form">
           <label class="muted">Daily amount <input type="number" id="valRecovery" min="0" style="width:80px"></label>
         </div>
-      </div>
-      <div class="edit-card">
-        <h3 style="margin:0 0 8px;font-size:1rem;font-weight:800;color:var(--ink)">Habit Values</h3>
+        <h4 style="margin:12px 0 8px;font-size:1rem;font-weight:800;color:var(--ink)">Habit Values</h4>
         <div class="form" id="habitSettings" style="flex-direction:column;align-items:flex-start"></div>
       </div>
       <div style="margin-top:12px">


### PR DESCRIPTION
## Summary
- Move habit value inputs inside the Recovery card in Settings
- Clarify README to note habit values live in the Recovery section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf55e491b8832f8e93c43afdd4527a