### PR TITLE
Remove data storage copy from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,8 +214,7 @@
       <h2 class="fab-avoid" style="margin:16px 0 8px;font-size:1.2rem;font-weight:800">Habits</h2>
       <div class="habit-list fab-avoid" id="habitList"></div>
 
-      <div class="footer fab-avoid">
-        <div>30d rolling = core. Data stored locally.</div>
+      <div class="footer fab-avoid" style="justify-content:flex-end">
         <div style="display:flex;gap:8px;">
           <div class="link" id="toHistory">History</div>
           <div class="link" id="toSettings">Settings</div>


### PR DESCRIPTION
## Summary
- remove data-storage copy from homepage footer and keep only History and Settings links

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf62b89c9c832f808eee4ebd6e48af