### PR TITLE
Hide quick action labels after tap

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,6 +731,13 @@
         }
       });
 
+      // Hide quick action labels shortly after activation
+      $$('.fab-btn').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          setTimeout(()=>btn.blur(), 1000);
+        });
+      });
+
     // Nav
     $('#toHistory').addEventListener('click', ()=>{
       $$('.screen').forEach(s=>s.classList.remove('active'));


### PR DESCRIPTION
## Summary
- Hide quick action button labels shortly after activation so they disappear automatically

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bff2032388832f8e8f0f3ed27888cd