### PR TITLE
Restore tooltip labels on keyboard focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
     .fab-btn:nth-child(4){animation:fab-in .3s ease forwards .15s}
     .fab-btn:nth-child(5){animation:fab-in .3s ease forwards .2s}
     .fab-btn::after{content:attr(data-tip);position:absolute;right:100%;top:50%;transform:translateY(-50%) translateX(-4px);background:var(--ink);color:#fff;padding:4px 8px;border-radius:8px;font-size:.8rem;white-space:nowrap;opacity:0;pointer-events:none;transition:opacity .2s ease,transform .2s ease}
-    .fab-btn:hover::after,.fab-btn.show-tip::after{opacity:1;transform:translateY(-50%) translateX(0)}
+    .fab-btn:hover::after,.fab-btn:focus-visible::after,.fab-btn.show-tip::after{opacity:1;transform:translateY(-50%) translateX(0)}
 
     .fab-btn.toggle{background:var(--gray)}
     body.fab-collapsed .fab-stack .fab-btn:not(.toggle){display:none}


### PR DESCRIPTION
## Summary
- Restore quick action tooltip visibility when FABs receive keyboard focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff492a7f8832fb32e70d3e3909840