### PR TITLE
Fix quick action labels and add basic lint step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -730,8 +730,6 @@
           notify('Nothing to undo');
         }
       });
-
-codex/make-quick-action-button-labels-temporary-c5a03m
       // Show quick action labels briefly on tap
       $$('.fab-btn').forEach(btn=>{
         btn.addEventListener('click', ()=>{
@@ -740,12 +738,6 @@ codex/make-quick-action-button-labels-temporary-c5a03m
             btn.classList.remove('show-tip');
             btn.blur();
           },1000);
-
-      // Hide quick action labels shortly after activation
-      $$('.fab-btn').forEach(btn=>{
-        btn.addEventListener('click', ()=>{
-          setTimeout(()=>btn.blur(), 1000);
-main
         });
       });
 

--- a/lint.js
+++ b/lint.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const html = fs.readFileSync('index.html', 'utf8');
+const match = html.match(/<script>([\s\S]*)<\/script>/);
+if (match) {
+  try {
+    new Function(match[1]);
+  } catch (e) {
+    console.error('JS syntax error:', e.message);
+    process.exit(1);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "treat",
+  "version": "1.0.0",
+  "description": "Repo for Treat app.",
+  "main": "sw.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "lint": "node lint.js",
+    "test": "npm run lint"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- remove merge artifacts and consolidate quick action label handler
- add Node-based lint script and npm test hook to catch syntax errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bff5bcd0f0832f8c9ad939dff783a0