### PR TITLE
Add comprehensive Treat app documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Repo for Treat app.
 
+## Documentation
+
+See [docs/app-documentation.md](docs/app-documentation.md) for a full user and developer manual including a feature breakdown and underlying logic.
+
 ## Customization
 
 The app includes a Settings page where you can change small, medium, and large cheat values as well as the daily recovery amount. Habit values can also be adjusted under the Recovery section. Each completed habit grants bonus recovery equal to its value for that day. The recovery cycle remains daily and the 80% health threshold is fixed. Recovery changes and habit value edits apply only to future days and do not alter past records.

--- a/docs/app-documentation.md
+++ b/docs/app-documentation.md
@@ -1,0 +1,43 @@
+# Treat App Manual
+
+## Problem & Goal
+Treat helps people manage indulgences without rigid dieting. The app tracks "treat" points against a daily recovery amount to keep users near the healthy 80% mark. Instead of counting calories, users record when they indulge and Treat shows how quickly they bounce back.
+
+## Using the App
+### Home screen
+- **Meter** – shows current health percentage and quick stats: allowed budget, used points, and points left.
+- **Floating buttons** – quickly log small, medium, or large treats for today. Use the undo button to remove the last quick entry.
+- **Challenge accordion** – optionally run a strict challenge for a set horizon. The app calculates an allowance, tracks spending, and reports if the user stays on track.
+
+### History view
+- Open via *History* button.
+- Use the date picker to choose any day.
+- Mark treats or bonus recovery for the selected date.
+- Each entry lists date, amount, and description (treat or recovery source).
+- Import or export CSV to back up or restore history.
+
+### Settings
+- Adjust treat sizes (small, medium, large) and daily recovery amount.
+- Manage habits: add, rename, delete, and set recovery value for each habit.
+- Saving settings updates future calculations without changing past data.
+
+## Feature Breakdown
+- **Treat Meter & Rolling Window** – Treat stores every treat in a local history. The `stats` function examines a rolling window (default 30 days). Debt above a 20% allowance pushes the meter below 80%.
+- **Daily Recovery & Habits** – The app subtracts a recovery amount each day. Completed habits grant bonus recovery equal to their value for that day. Bonuses stack with manual entries.
+- **Streaks & Predictions** – `stats` also calculates current and best healthy streaks. If the user exceeds the allowance, the app estimates the date health returns to 80% based on daily recovery.
+- **Challenge Mode** – A separate tracker with strict allowance and no decay. Users choose a horizon; Treat counts treats in that range and reports remaining budget.
+- **Import/Export** – CSV import merges new rows into existing history. Export produces a full CSV with treat and recovery rows for the entire history.
+- **Offline-first PWA** – A service worker caches core files (`sw.js`) so the app works offline and updates in the background.
+
+## Hidden Mechanisms
+- **Local Storage Keys** – Treat persists data in localStorage: `mvp_points_v1` for treats, `mvp_prefs_v1` for settings, `mvp_recovery_hist_v1` for recovery changes, `mvp_bonus_hist_v1` for habit and manual bonuses, and `treat_habits_v1` for habit definitions.
+- **Automatic Day Rollover** – A timer checks the date every minute. When the day changes, it recalculates bonuses, resets habit checkboxes, and re-renders stats.
+- **Calculation Details** – `addPoints` stores positive numbers per day. `stats` walks the window, applying daily recovery before treats to model debt. Recovery rows record how much daily, habit, and manual recovery was applied.
+- **Target Marker** – The meter marks 80% as the ideal point. The `describeTreat` helper converts raw points into small/medium/large descriptions.
+
+## Developer Notes
+- Single-page app (`index.html`) with inline JavaScript modules and CSS.
+- Build/format checks: `npm test` runs the custom `lint.js` script.
+- Service worker caching logic lives in `sw.js`.
+- No external dependencies; everything runs in the browser.
+


### PR DESCRIPTION
## Summary
- Document Treat's goals, features, and internal logic in a full manual.
- Link the main README to the new documentation for easy access.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c046792b8c832f9e1a41655344d363