### PR TITLE
Prevent bottom nav from overlapping page content

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,13 @@
       --nav-h:calc(64px + env(safe-area-inset-bottom));
     }
     body.fab-collapsed{--fab-h:96px;}
-    html,body{height:100%}
+    html,body{min-height:100%}
     body{
       margin:0;
       background:var(--bg);
       color:var(--ink);
       display:flex;justify-content:center;
+      padding-bottom:var(--nav-h);
       font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;
       -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
     }


### PR DESCRIPTION
## Summary
- Allow page height to grow beyond the viewport to keep content above the bottom navigation
- Add body padding equal to nav height so long pages such as History remain fully visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c15e70fa34832fb33df6ff54d5b425