### PR TITLE
Fix inconsistent import/export data

### DIFF
--- a/docs/app-documentation.md
+++ b/docs/app-documentation.md
@@ -26,7 +26,7 @@ Treat helps people manage indulgences without rigid dieting. The app tracks "tre
 - **Daily Recovery & Habits** – The app subtracts a recovery amount each day. Completed habits grant bonus recovery equal to their value for that day. Bonuses stack with manual entries.
 - **Streaks & Predictions** – `stats` also calculates current and best healthy streaks. If the user exceeds the allowance, the app estimates the date health returns to 80% based on daily recovery.
 - **Challenge Mode** – A separate tracker with strict allowance and no decay. Users choose a horizon; Treat counts treats in that range and reports remaining budget.
-- **Import/Export** – CSV import merges new rows into existing history. Export produces a full CSV with treat and recovery rows for the entire history.
+- **Import/Export** – Export creates a CSV of raw treat history. Importing a CSV merges those rows into existing data and recalculates recovery.
 - **Offline-first PWA** – A service worker caches core files (`sw.js`) so the app works offline and updates in the background.
 
 ## Hidden Mechanisms

--- a/index.html
+++ b/index.html
@@ -579,10 +579,7 @@
 
     function exportData(){
       const st=load();
-      const start = st.data.length ? st.data.reduce((m,r)=>r.date<m?r.date:m, st.data[0].date) : todayStr();
-      const windowDays = diffDays(start, todayStr()) + 1;
-      const s = stats(st.data, windowDays);
-      const rows=[["date","points","type","description"], ...s.rows.map(r=>[r.date, Math.abs(r.n), r.type, describeRow(r)])];
+      const rows=[["date","points"], ...st.data.map(r=>[r.date,r.n])];
       const csv=rows.map(r=>r.join(',')).join('\n');
       const blob=new Blob([csv],{type:'text/csv'});
       const url=URL.createObjectURL(blob);
@@ -599,9 +596,8 @@
         const parts=line.split(',');
         const date=parts[0];
         const pts=parts[1];
-        const type=parts[2]||'treat';
         const n=Math.max(0,Number(pts)||0);
-        if(date && String(type).trim().toLowerCase()!=='recovery') imported.push({date:date.trim(),n});
+        if(date && n>0) imported.push({date:date.trim(),n});
       }
       if(imported.length===0){notify('No data found');return;}
       const st=load();


### PR DESCRIPTION
## Summary
- Restore CSV-based import/export and drop JSON backup
- Export raw treat history as CSV and merge treat rows on import
- Update documentation and UI to clarify CSV-only backups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c15feee7c0832fa3b8baed27f8a40e